### PR TITLE
Added acceptance of already hashed passwords

### DIFF
--- a/.versions
+++ b/.versions
@@ -12,14 +12,14 @@ id-map@1.0.3
 jquery@1.11.3_2
 json@1.0.3
 livedata@1.0.13
-local-test:ongoworks:ddp-login@0.2.1
+local-test:ongoworks:ddp-login@0.2.2
 localstorage@1.0.3
 logging@1.0.7
 meteor@1.1.6
 minimongo@1.0.8
 mongo@1.1.0
 npm-bcrypt@0.7.8_2
-ongoworks:ddp-login@0.2.1
+ongoworks:ddp-login@0.2.2
 ordered-dict@1.0.3
 random@1.0.3
 retry@1.0.3

--- a/ddp-login-tests.js
+++ b/ddp-login-tests.js
@@ -30,7 +30,6 @@ if (Meteor.isServer) {
   });
 
   Tinytest.add('ddp-login - sync - with plain password', function(test) {
-  	console.log(Accounts);
     var conn = DDP.connect(Meteor.absoluteUrl());
     test.isTrue(!!conn);
     var result = conn.call('tester');

--- a/ddp-login-tests.js
+++ b/ddp-login-tests.js
@@ -29,7 +29,8 @@ if (Meteor.isServer) {
     next();
   });
 
-  Tinytest.add('ddp-login - sync', function(test) {
+  Tinytest.add('ddp-login - sync - with plain password', function(test) {
+  	console.log(Accounts);
     var conn = DDP.connect(Meteor.absoluteUrl());
     test.isTrue(!!conn);
     var result = conn.call('tester');
@@ -42,11 +43,30 @@ if (Meteor.isServer) {
     // Result will be true because we are logged in
     test.isTrue(result);
   });
+
+	Tinytest.add('ddp-login - sync - with digest password', function(test) {
+		var conn = DDP.connect(Meteor.absoluteUrl());
+		test.isTrue(!!conn);
+		var result = conn.call('tester');
+		// Result will be false because we are not logged in
+		test.isFalse(result);
+
+		const password = {
+			digest: SHA256('admin'),
+			algorithm: "sha-256"
+		};
+
+		// Now log in
+		DDP.loginWithPassword(conn, {username: 'admin'}, password);
+		// Now try the method call again as an authenticated user
+		result = conn.call('tester');
+		// Result will be true because we are logged in
+		test.isTrue(result);
+	});
 }
 
 Tinytest.addAsync('ddp-login - login', function(test, next) {
   var conn = DDP.connect(Meteor.absoluteUrl());
-
   test.isTrue(!!conn);
 
   conn.call('tester', function (error, result) {

--- a/ddp-login.js
+++ b/ddp-login.js
@@ -82,6 +82,11 @@ function loginWithPassword(connection, selector, password, callback) {
   // Use new method as of Meteor 0.8.2
   else {
     function hashPassword(password) {
+      // If the password is already in the desired format, we don't need
+      // to hash it.
+      if (password.digest && password.algorithm)
+        return password;
+
       return {
         digest: SHA256(password),
         algorithm: "sha-256"

--- a/ddp-login.js
+++ b/ddp-login.js
@@ -41,13 +41,13 @@ function loginWithPassword(connection, selector, password, callback) {
       return;
 
     if (error || !result) {
-      onceUserCallback(error || new Error("No result from call to login"));
+      onceUserCallback(error || new Error("No result from call to login"), null);
     } else if (srp && !srp.verifyConfirmation({HAMK: result.HAMK})) {
-      onceUserCallback(new Error("Server is cheating!"));
+      onceUserCallback(new Error("Server is cheating!"), null);
     } else {
       // Logged in
       connection.setUserId(result.id);
-      onceUserCallback();
+      onceUserCallback(null, result);
     }
   }
 

--- a/package.js
+++ b/package.js
@@ -6,12 +6,12 @@ Package.describe({
 });
 
 Package.on_use(function (api) {
-  api.versionsFrom("METEOR@0.9.0")
+  api.versionsFrom(["METEOR@0.9.0","METEOR@1.4.2"]);
   api.use(['livedata', 'underscore', 'srp', 'sha']);
   api.add_files(['ddp-login.js']);
 });
 
 Package.on_test(function(api) {
-  api.use(['accounts-password', 'ongoworks:ddp-login', 'test-helpers', 'tinytest']);
+  api.use(['accounts-password@1.3.4', 'ongoworks:ddp-login@0.2.2', 'test-helpers', 'tinytest', 'ddp', 'sha']);
   api.add_files(["ddp-login-tests.js"]);
 });

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   summary: "Securely log in to a non-primary DDP connection from another browser or server",
   name: "ongoworks:ddp-login",
-  version: "0.2.1",
+  version: "0.2.2",
   git: "https://github.com/ongoworks/meteor-ddp-login.git"
 });
 


### PR DESCRIPTION
Hi, I know it's unusual but I came across an issue in my App which I immediatly solved:

If the password is passed in already hashed format, such as

```javascript
{digest:"...lotsofcharshere", algorithm:"sha-256"}
```

then the method should be able to use it directly. Tests were updated, so the methods are running. Only thing is that I had to update the accounts-password dependency, but just for the tests, otherwise the old bcrypt had fired lots of errors.

Background: There is the case, where I want to connect (on the server) to a remote via DDP but do not want or can use the plaintext password. Instead I then hook into the Accounts.onLogin and use the password from the login there, which is already in hashed format as described above. I do that to load remote collections from my admin application via DDP.

I hope this PR makes any sense to you.